### PR TITLE
chore: Update chatGroup.css to hide panel button in chat__group

### DIFF
--- a/src/views/chatGroup.css
+++ b/src/views/chatGroup.css
@@ -4,7 +4,7 @@
     height: 10vh;
 }
 
-#btn__panel {
+.chat__group #btn__panel {
     display: none;
 }
 


### PR DESCRIPTION
  Hola @abengl , te genero de nuevo un Pull, porque me fijé que el botón panel se estaba ocultando en todas las vistas, y solo necesitamos que oculte en el chat grupal. Entonces, hice una modificación.

```
.chat__group #btn__panel {
    display: none;
}
```